### PR TITLE
DR Legs update gains to rad

### DIFF
--- a/disneyresearch/dr_legs/usd/dr_legs.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs.usda
@@ -1171,8 +1171,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1193,8 +1193,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1260,8 +1260,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1282,8 +1282,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1349,8 +1349,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1431,8 +1431,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1483,8 +1483,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1505,8 +1505,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1572,8 +1572,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1594,8 +1594,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1661,8 +1661,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1743,8 +1743,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs.usda
@@ -1171,8 +1171,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1193,8 +1193,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1260,8 +1260,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1282,8 +1282,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1349,8 +1349,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1431,8 +1431,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1483,8 +1483,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1505,8 +1505,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1572,8 +1572,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1594,8 +1594,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1661,8 +1661,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1743,8 +1743,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs.usda
@@ -1171,8 +1171,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1193,8 +1193,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1260,8 +1260,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1282,8 +1282,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1349,8 +1349,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1431,8 +1431,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1483,8 +1483,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1505,8 +1505,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1572,8 +1572,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1594,8 +1594,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1661,8 +1661,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1743,8 +1743,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
@@ -616,8 +616,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -638,8 +638,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -705,8 +705,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -727,8 +727,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -794,8 +794,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -876,8 +876,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -928,8 +928,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -950,8 +950,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1017,8 +1017,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1039,8 +1039,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1106,8 +1106,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1188,8 +1188,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
@@ -616,8 +616,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -638,8 +638,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -705,8 +705,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -727,8 +727,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -794,8 +794,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -876,8 +876,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -928,8 +928,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -950,8 +950,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1017,8 +1017,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1039,8 +1039,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1106,8 +1106,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1188,8 +1188,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
@@ -616,8 +616,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -638,8 +638,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -705,8 +705,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -727,8 +727,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -794,8 +794,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -876,8 +876,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -928,8 +928,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -950,8 +950,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1017,8 +1017,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1039,8 +1039,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1106,8 +1106,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1188,8 +1188,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
@@ -1187,8 +1187,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1209,8 +1209,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1276,8 +1276,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1298,8 +1298,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1365,8 +1365,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1447,8 +1447,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1499,8 +1499,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1521,8 +1521,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1588,8 +1588,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1610,8 +1610,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1677,8 +1677,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1759,8 +1759,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 50.0
-            float drive:angular:physics:damping = 1.0
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
@@ -1187,8 +1187,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1209,8 +1209,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1276,8 +1276,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1298,8 +1298,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1365,8 +1365,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1447,8 +1447,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1499,8 +1499,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1521,8 +1521,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1588,8 +1588,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1610,8 +1610,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1677,8 +1677,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1759,8 +1759,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
+            float drive:angular:physics:stiffness = 2864.788975654
+            float drive:angular:physics:damping = 57.295779513
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 

--- a/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
@@ -1187,8 +1187,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1209,8 +1209,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1276,8 +1276,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1298,8 +1298,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1365,8 +1365,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1447,8 +1447,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1499,8 +1499,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1521,8 +1521,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1588,8 +1588,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1610,8 +1610,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1677,8 +1677,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
@@ -1759,8 +1759,8 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 2864.788975654
-            float drive:angular:physics:damping = 57.295779513
+            float drive:angular:physics:stiffness = 0.872664626
+            float drive:angular:physics:damping = 0.017453293
             uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing an asset to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description

Converts the PD control gains for the DR Legs joints from degree-based units to radian-based units     
  across all three USD asset variants:

  - dr_legs.usda
  - dr_legs_with_boxes.usda
  - dr_legs_with_meshes_and_boxes.usda


## Before your PR is "Ready for review"

- [x] The asset folder and file structure follows the guidelines in the [README](../README.md)
- [x] The asset license allows adding to this repository, see [README](../README.md)
- [x] A LICENSE file is present
- [x] A README.md file is present that describes the asset and its origin, and provides a changelog, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted angular drive stiffness and damping across multiple leg joints to refine simulation behavior and stability; no structural changes to joints or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->