### PR TITLE
Add KaminoSceneAPI attributes to Disney Research `DR Legs` assets

### DIFF
--- a/disneyresearch/dr_legs/usd/dr_legs.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs.usda
@@ -19,6 +19,18 @@
     upAxis = "Z"
 )
 
+def PhysicsScene "PhysicsScene" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
+{
+    uniform float newton:kamino:padmm:primalTolerance = 1e-4
+    uniform float newton:kamino:padmm:dualTolerance = 1e-4
+    uniform float newton:kamino:padmm:complementarityTolerance = 1e-4
+    uniform float newton:kamino:constraints:alpha = 0.1
+    uniform float newton:kamino:constraints:beta = 0.011
+    uniform float newton:kamino:constraints:gamma = 0.05
+}
+
 def Xform "DR_Legs"
 {
     def Scope "RigidBodies"

--- a/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
@@ -21,6 +21,18 @@
     upAxis = "Z"
 )
 
+def PhysicsScene "PhysicsScene" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
+{
+    uniform float newton:kamino:padmm:primalTolerance = 1e-4
+    uniform float newton:kamino:padmm:dualTolerance = 1e-4
+    uniform float newton:kamino:padmm:complementarityTolerance = 1e-4
+    uniform float newton:kamino:constraints:alpha = 0.1
+    uniform float newton:kamino:constraints:beta = 0.011
+    uniform float newton:kamino:constraints:gamma = 0.05
+}
+
 def Xform "DR_Legs"
 {
     def Scope "RigidBodies"

--- a/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
@@ -21,6 +21,18 @@
     upAxis = "Z"
 )
 
+def PhysicsScene "PhysicsScene" (
+    prepend apiSchemas = ["NewtonKaminoSceneAPI"]
+)
+{
+    uniform float newton:kamino:padmm:primalTolerance = 1e-4
+    uniform float newton:kamino:padmm:dualTolerance = 1e-4
+    uniform float newton:kamino:padmm:complementarityTolerance = 1e-4
+    uniform float newton:kamino:constraints:alpha = 0.1
+    uniform float newton:kamino:constraints:beta = 0.011
+    uniform float newton:kamino:constraints:gamma = 0.05
+}
+
 def Xform "DR_Legs"
 {
     def Scope "RigidBodies"


### PR DESCRIPTION
## Description

This PR adds solver attributes described by the `KaminoSceneAPI` to the `DR Legs` assets, to be parsed by the USD Importer and picked up by `SolverKamino`.

## Before your PR is "Ready for review"

- [x] The asset folder and file structure follows the guidelines in the [README](../README.md)
- [x] The asset license allows adding to this repository, see [README](../README.md)
- [x] A LICENSE file is present
- [x] A README.md file is present that describes the asset and its origin, and provides a changelog, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added physics scene configuration with Newton-Kamino solver parameters, including adjustable tolerance and constraint settings (primal tolerance, dual tolerance, complementarity tolerance, alpha, beta, gamma) to scene definitions for enhanced simulation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->