### PR TITLE
Remove placeholder values for centerOfMass of ur10 asset

### DIFF
--- a/universal_robots_ur10/README.md
+++ b/universal_robots_ur10/README.md
@@ -14,6 +14,10 @@ The USD model was collected using IsaacSim from the IsaacLab robot assets. The s
 
 For changes made to the model for simulation in Newton, please refer to the Git commit history of this folder.
 
+### Changelog
+
+- 2026-03-16: Removed `physics:centerOfMass` in `usd/ur10_instanceable.usda`.
+
 ## License
 
 This model is released under a [BSD-3-Clause License](LICENSE).

--- a/universal_robots_ur10/README.md
+++ b/universal_robots_ur10/README.md
@@ -16,7 +16,7 @@ For changes made to the model for simulation in Newton, please refer to the Git 
 
 ### Changelog
 
-- 2026-03-16: Removed `physics:centerOfMass` in `usd/ur10_instanceable.usda` to fix mass distribution isssue.
+- 2026-03-16: Removed `physics:centerOfMass` in `usd/ur10_instanceable.usda` to fix mass distribution issue.
 
 ## License
 

--- a/universal_robots_ur10/README.md
+++ b/universal_robots_ur10/README.md
@@ -16,7 +16,7 @@ For changes made to the model for simulation in Newton, please refer to the Git 
 
 ### Changelog
 
-- 2026-03-16: Removed `physics:centerOfMass` in `usd/ur10_instanceable.usda`.
+- 2026-03-16: Removed `physics:centerOfMass` in `usd/ur10_instanceable.usda` to fix mass distribution isssue.
 
 ## License
 

--- a/universal_robots_ur10/usd/ur10_instanceable.usda
+++ b/universal_robots_ur10/usd/ur10_instanceable.usda
@@ -130,7 +130,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         float physics:mass = 200
         vector3f physics:velocity = (0, 0, 0)
         quatf xformOp:orient = (1, 0, 0, 0)
@@ -225,7 +224,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         float physics:mass = 7.1
         vector3f physics:velocity = (0, 0, 0)
         quatf xformOp:orient = (1, 0, 0, 0)
@@ -379,7 +377,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         bool physics:kinematicEnabled = 0
         float physics:mass = 12.7
         bool physics:rigidBodyEnabled = 1
@@ -572,7 +569,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         bool physics:kinematicEnabled = 0
         float physics:mass = 4.27
         bool physics:rigidBodyEnabled = 1
@@ -765,7 +761,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         bool physics:kinematicEnabled = 0
         float physics:mass = 1
         bool physics:rigidBodyEnabled = 1
@@ -942,7 +937,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         bool physics:kinematicEnabled = 0
         float physics:mass = 1
         bool physics:rigidBodyEnabled = 1
@@ -1112,7 +1106,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         bool physics:kinematicEnabled = 0
         float physics:mass = 0.365
         bool physics:rigidBodyEnabled = 1
@@ -1220,7 +1213,6 @@ def Xform "ur10" (
     )
     {
         vector3f physics:angularVelocity = (0, 0, 0)
-        point3f physics:centerOfMass = (0, 0, 0)
         bool physics:kinematicEnabled = 0
         float physics:mass = 0.01
         bool physics:rigidBodyEnabled = 1


### PR DESCRIPTION
## Description
Closes:
https://github.com/newton-physics/newton/issues/2047


## Before your PR is "Ready for review"

- [x] The asset folder and file structure follows the guidelines in the [README](../README.md)
- [x] The asset license allows adding to this repository, see [README](../README.md)
- [x] A LICENSE file is present
- [x] A README.md file is present that describes the asset and its origin, and provides a changelog, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit center-of-mass attributes from all UR10 body segments (base, shoulder, upper arm, forearm, wrist links, and end-effector), so physics center-of-mass will be defaulted or computed rather than explicitly specified.

* **Documentation**
  * Added a changelog entry noting the removal of physics:centerOfMass from the USD asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->