### PR TITLE
Add articulations to DR models

### DIFF
--- a/disneyresearch/dr_legs/README.md
+++ b/disneyresearch/dr_legs/README.md
@@ -9,6 +9,9 @@ and actuated joints with multiple closed kinematic loops, originally presented b
 
 ## Changelog
 
+### [06/12/2026]
+- Add articulations to models.
+
 ### [03/10/2026]
 - Add RL walk policy.
 

--- a/disneyresearch/dr_legs/usd/dr_legs.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs.usda
@@ -23,12 +23,12 @@ def PhysicsScene "PhysicsScene" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    uniform float newton:kamino:padmm:primalTolerance = 1e-4
-    uniform float newton:kamino:padmm:dualTolerance = 1e-4
-    uniform float newton:kamino:padmm:complementarityTolerance = 1e-4
     uniform float newton:kamino:constraints:alpha = 0.1
     uniform float newton:kamino:constraints:beta = 0.011
     uniform float newton:kamino:constraints:gamma = 0.05
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "DR_Legs"
@@ -36,7 +36,7 @@ def Xform "DR_Legs"
     def Scope "RigidBodies"
     {
         def Xform "pelvis" (
-            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsArticulationRootAPI"]
             customData = {
                 string uuid = "b94e9fc1-7daf-4ca6-8ea3-39f618072e50"
             }
@@ -1161,7 +1161,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/pelvis>
             rel physics:body1 = </DR_Legs/RigidBodies/hip_servos_l_i>
@@ -1171,9 +1174,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j2_l_i" (
@@ -1183,7 +1183,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_l_i>
@@ -1193,9 +1196,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_l_i" (
@@ -1250,19 +1250,19 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
-            rel physics:body0 = </DR_Legs/RigidBodies/foot_l>
-            rel physics:body1 = </DR_Legs/RigidBodies/ankle_bracket_b_l_i>
-            point3f physics:localPos0 = (-0.0026218395, -0.032362416, 0.014059638)
-            point3f physics:localPos1 = (0.0010595453, -0.0060089943, -7.050231e-9)
-            quatf physics:localRot0 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
-            quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
+            rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_l_i>
+            rel physics:body1 = </DR_Legs/RigidBodies/foot_l>
+            point3f physics:localPos0 = (0.0010595453, -0.0060089943, -7.050231e-9)
+            point3f physics:localPos1 = (-0.0026218395, -0.032362416, 0.014059638)
+            quatf physics:localRot0 = (-0.058084864, 0.6401578, 0.7629104, -0.069222845)
+            quatf physics:localRot1 = (-0.058084864, 0.6401578, 0.7629104, -0.069222845)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j7_l_i" (
@@ -1272,7 +1272,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_l_i>
@@ -1282,9 +1285,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_l_i" (
@@ -1311,6 +1311,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_l_i>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0032588597, -0.0004986371, -0.063249186)
             point3f physics:localPos1 = (0.04034986, -0.004129176, 0.049305025)
             quatf physics:localRot0 = (0.7657849, -0.019939138, 0.016730923, -0.64256984)
@@ -1339,7 +1340,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_l_o>
@@ -1349,9 +1353,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_l_o" (
@@ -1408,6 +1409,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/foot_l>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0010595475, 0.0060089934, 5.228326e-9)
             point3f physics:localPos1 = (-0.013648499, 0.030172877, 0.014059638)
             quatf physics:localRot0 = (-0.05952467, 0.64002556, 0.7627528, -0.07093874)
@@ -1421,7 +1423,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_l_o>
@@ -1431,9 +1436,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_l_o" (
@@ -1460,6 +1462,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_l_o>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0035088737, -0.0005427213, -0.06323544)
             point3f physics:localPos1 = (0.036696207, 0.017866438, 0.049128935)
             quatf physics:localRot0 = (0.7657433, -0.021476122, 0.018020606, -0.642535)
@@ -1473,7 +1476,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/pelvis>
             rel physics:body1 = </DR_Legs/RigidBodies/hip_servos_r_i>
@@ -1483,9 +1489,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j2_r_i" (
@@ -1495,7 +1498,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_r_i>
@@ -1505,9 +1511,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_r_i" (
@@ -1562,19 +1565,19 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
-            rel physics:body0 = </DR_Legs/RigidBodies/foot_r>
-            rel physics:body1 = </DR_Legs/RigidBodies/ankle_bracket_b_r_i>
-            point3f physics:localPos0 = (-0.0026218148, 0.03236255, 0.0140596405)
-            point3f physics:localPos1 = (0.0010595476, 0.0060089934, -5.228582e-9)
-            quatf physics:localRot0 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
-            quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
+            rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_r_i>
+            rel physics:body1 = </DR_Legs/RigidBodies/foot_r>
+            point3f physics:localPos0 = (0.0010595476, 0.0060089934, -5.228582e-9)
+            point3f physics:localPos1 = (-0.0026218148, 0.03236255, 0.0140596405)
+            quatf physics:localRot0 = (-0.058084864, -0.6401578, 0.7629104, 0.069222845)
+            quatf physics:localRot1 = (-0.058084864, -0.6401578, 0.7629104, 0.069222845)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j7_r_i" (
@@ -1584,7 +1587,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_r_i>
@@ -1594,9 +1600,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_r_i" (
@@ -1623,6 +1626,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_r_i>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0032328705, 0.0006460301, -0.063249186)
             point3f physics:localPos1 = (0.040375788, 0.0042765774, 0.049304985)
             quatf physics:localRot0 = (-0.64256984, 0.016730923, -0.019939138, 0.7657849)
@@ -1651,7 +1655,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_r_o>
@@ -1661,9 +1668,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_r_o" (
@@ -1720,6 +1724,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/foot_r>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0010595495, -0.0060089934, -4.9155724e-9)
             point3f physics:localPos1 = (-0.013648474, -0.030172743, 0.0140596405)
             quatf physics:localRot0 = (0.48918638, 0.5895089, 0.4946567, 0.41047612)
@@ -1733,7 +1738,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_r_o>
@@ -1743,9 +1751,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_r_o" (
@@ -1772,6 +1777,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_r_o>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0034828843, 0.0006901143, -0.06323544)
             point3f physics:localPos1 = (0.036722384, -0.0177191, 0.049129155)
             quatf physics:localRot0 = (-0.642535, 0.018020606, -0.021476122, 0.7657433)
@@ -1791,3 +1797,4 @@ def Xform "DR_Legs"
         }
     }
 }
+

--- a/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
@@ -25,12 +25,12 @@ def PhysicsScene "PhysicsScene" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    uniform float newton:kamino:padmm:primalTolerance = 1e-4
-    uniform float newton:kamino:padmm:dualTolerance = 1e-4
-    uniform float newton:kamino:padmm:complementarityTolerance = 1e-4
     uniform float newton:kamino:constraints:alpha = 0.1
     uniform float newton:kamino:constraints:beta = 0.011
     uniform float newton:kamino:constraints:gamma = 0.05
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "DR_Legs"
@@ -38,7 +38,7 @@ def Xform "DR_Legs"
     def Scope "RigidBodies"
     {
         def Xform "pelvis" (
-            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsArticulationRootAPI"]
             customData = {
                 string uuid = "b94e9fc1-7daf-4ca6-8ea3-39f618072e50"
             }
@@ -63,11 +63,11 @@ def Xform "DR_Legs"
                         }
                     )
                     {
-                        color3f[] primvars:displayColor = [(0.2784314, 0.4117647, 1)]
                         float3[] extent = [(-1, -1, -1), (1, 1, 1)]
-                        float3 xformOp:scale = (0.0425, 0.12, 0.0275)
+                        color3f[] primvars:displayColor = [(0.2784314, 0.4117647, 1)]
                         float3 xformOp:rotateXYZ = (0, 0, 0)
-                        double3 xformOp:translate = (7.5e-06, 0.0, -7.5e-06)
+                        float3 xformOp:scale = (0.0425, 0.12, 0.0275)
+                        double3 xformOp:translate = (0.0000075, 0, -0.0000075)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
                     }
                 }
@@ -420,10 +420,10 @@ def Xform "DR_Legs"
                         }
                     )
                     {
-                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3[] extent = [(-1, -1, -1), (1, 1, 1)]
-                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
+                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3 xformOp:rotateXYZ = (0, 0, 10)
+                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
                         double3 xformOp:translate = (-0.003703450760000001, -0.00031338953000001335, -0.016440363749999964)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
                     }
@@ -457,10 +457,10 @@ def Xform "DR_Legs"
                         }
                     )
                     {
-                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3[] extent = [(-1, -1, -1), (1, 1, 1)]
-                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
+                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3 xformOp:rotateXYZ = (0, 0, -10)
+                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
                         double3 xformOp:translate = (-0.003703450760000001, 0.00031338953000001335, -0.016440363749999964)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
                     }
@@ -606,7 +606,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/pelvis>
             rel physics:body1 = </DR_Legs/RigidBodies/hip_servos_l_i>
@@ -616,9 +619,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j2_l_i" (
@@ -628,7 +628,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_l_i>
@@ -638,9 +641,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_l_i" (
@@ -695,19 +695,19 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
-            rel physics:body0 = </DR_Legs/RigidBodies/foot_l>
-            rel physics:body1 = </DR_Legs/RigidBodies/ankle_bracket_b_l_i>
-            point3f physics:localPos0 = (-0.0026218395, -0.032362416, 0.014059638)
-            point3f physics:localPos1 = (0.0010595453, -0.0060089943, -7.050231e-9)
-            quatf physics:localRot0 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
-            quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
+            rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_l_i>
+            rel physics:body1 = </DR_Legs/RigidBodies/foot_l>
+            point3f physics:localPos0 = (0.0010595453, -0.0060089943, -7.050231e-9)
+            point3f physics:localPos1 = (-0.0026218395, -0.032362416, 0.014059638)
+            quatf physics:localRot0 = (-0.058084864, 0.6401578, 0.7629104, -0.069222845)
+            quatf physics:localRot1 = (-0.058084864, 0.6401578, 0.7629104, -0.069222845)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j7_l_i" (
@@ -717,7 +717,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_l_i>
@@ -727,9 +730,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_l_i" (
@@ -756,6 +756,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_l_i>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0032588597, -0.0004986371, -0.063249186)
             point3f physics:localPos1 = (0.04034986, -0.004129176, 0.049305025)
             quatf physics:localRot0 = (0.7657849, -0.019939138, 0.016730923, -0.64256984)
@@ -784,7 +785,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_l_o>
@@ -794,9 +798,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_l_o" (
@@ -853,6 +854,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/foot_l>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0010595475, 0.0060089934, 5.228326e-9)
             point3f physics:localPos1 = (-0.013648499, 0.030172877, 0.014059638)
             quatf physics:localRot0 = (-0.05952467, 0.64002556, 0.7627528, -0.07093874)
@@ -866,7 +868,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_l_o>
@@ -876,9 +881,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_l_o" (
@@ -905,6 +907,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_l_o>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0035088737, -0.0005427213, -0.06323544)
             point3f physics:localPos1 = (0.036696207, 0.017866438, 0.049128935)
             quatf physics:localRot0 = (0.7657433, -0.021476122, 0.018020606, -0.642535)
@@ -918,7 +921,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/pelvis>
             rel physics:body1 = </DR_Legs/RigidBodies/hip_servos_r_i>
@@ -928,9 +934,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j2_r_i" (
@@ -940,7 +943,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_r_i>
@@ -950,9 +956,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_r_i" (
@@ -1007,19 +1010,19 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
-            rel physics:body0 = </DR_Legs/RigidBodies/foot_r>
-            rel physics:body1 = </DR_Legs/RigidBodies/ankle_bracket_b_r_i>
-            point3f physics:localPos0 = (-0.0026218148, 0.03236255, 0.0140596405)
-            point3f physics:localPos1 = (0.0010595476, 0.0060089934, -5.228582e-9)
-            quatf physics:localRot0 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
-            quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
+            rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_r_i>
+            rel physics:body1 = </DR_Legs/RigidBodies/foot_r>
+            point3f physics:localPos0 = (0.0010595476, 0.0060089934, -5.228582e-9)
+            point3f physics:localPos1 = (-0.0026218148, 0.03236255, 0.0140596405)
+            quatf physics:localRot0 = (-0.058084864, -0.6401578, 0.7629104, 0.069222845)
+            quatf physics:localRot1 = (-0.058084864, -0.6401578, 0.7629104, 0.069222845)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j7_r_i" (
@@ -1029,7 +1032,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_r_i>
@@ -1039,9 +1045,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_r_i" (
@@ -1068,6 +1071,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_r_i>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0032328705, 0.0006460301, -0.063249186)
             point3f physics:localPos1 = (0.040375788, 0.0042765774, 0.049304985)
             quatf physics:localRot0 = (-0.64256984, 0.016730923, -0.019939138, 0.7657849)
@@ -1096,7 +1100,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_r_o>
@@ -1106,9 +1113,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_r_o" (
@@ -1165,6 +1169,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/foot_r>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0010595495, -0.0060089934, -4.9155724e-9)
             point3f physics:localPos1 = (-0.013648474, -0.030172743, 0.0140596405)
             quatf physics:localRot0 = (0.48918638, 0.5895089, 0.4946567, 0.41047612)
@@ -1178,7 +1183,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_r_o>
@@ -1188,9 +1196,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_r_o" (
@@ -1217,6 +1222,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_r_o>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0034828843, 0.0006901143, -0.06323544)
             point3f physics:localPos1 = (0.036722384, -0.0177191, 0.049129155)
             quatf physics:localRot0 = (-0.642535, 0.018020606, -0.021476122, 0.7657433)
@@ -1236,3 +1242,4 @@ def Xform "DR_Legs"
         }
     }
 }
+

--- a/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
@@ -25,12 +25,12 @@ def PhysicsScene "PhysicsScene" (
     prepend apiSchemas = ["NewtonKaminoSceneAPI"]
 )
 {
-    uniform float newton:kamino:padmm:primalTolerance = 1e-4
-    uniform float newton:kamino:padmm:dualTolerance = 1e-4
-    uniform float newton:kamino:padmm:complementarityTolerance = 1e-4
     uniform float newton:kamino:constraints:alpha = 0.1
     uniform float newton:kamino:constraints:beta = 0.011
     uniform float newton:kamino:constraints:gamma = 0.05
+    uniform float newton:kamino:padmm:complementarityTolerance = 0.0001
+    uniform float newton:kamino:padmm:dualTolerance = 0.0001
+    uniform float newton:kamino:padmm:primalTolerance = 0.0001
 }
 
 def Xform "DR_Legs"
@@ -38,7 +38,7 @@ def Xform "DR_Legs"
     def Scope "RigidBodies"
     {
         def Xform "pelvis" (
-            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsArticulationRootAPI"]
             customData = {
                 string uuid = "b94e9fc1-7daf-4ca6-8ea3-39f618072e50"
             }
@@ -76,11 +76,11 @@ def Xform "DR_Legs"
                         }
                     )
                     {
-                        color3f[] primvars:displayColor = [(0.2784314, 0.4117647, 1)]
                         float3[] extent = [(-1, -1, -1), (1, 1, 1)]
-                        float3 xformOp:scale = (0.0425, 0.12, 0.0275)
+                        color3f[] primvars:displayColor = [(0.2784314, 0.4117647, 1)]
                         float3 xformOp:rotateXYZ = (0, 0, 0)
-                        double3 xformOp:translate = (7.5e-06, 0.0, -7.5e-06)
+                        float3 xformOp:scale = (0.0425, 0.12, 0.0275)
+                        double3 xformOp:translate = (0.0000075, 0, -0.0000075)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
                     }
                 }
@@ -826,10 +826,10 @@ def Xform "DR_Legs"
                         }
                     )
                     {
-                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3[] extent = [(-1, -1, -1), (1, 1, 1)]
-                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
+                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3 xformOp:rotateXYZ = (0, 0, 10)
+                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
                         double3 xformOp:translate = (-0.003703450760000001, -0.00031338953000001335, -0.016440363749999964)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
                     }
@@ -876,10 +876,10 @@ def Xform "DR_Legs"
                         }
                     )
                     {
-                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3[] extent = [(-1, -1, -1), (1, 1, 1)]
-                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
+                        color3f[] primvars:displayColor = [(0.1, 0.1, 0.1)]
                         float3 xformOp:rotateXYZ = (0, 0, -10)
+                        float3 xformOp:scale = (0.0585, 0.035, 0.0015)
                         double3 xformOp:translate = (-0.003703450760000001, 0.00031338953000001335, -0.016440363749999964)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
                     }
@@ -1177,7 +1177,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/pelvis>
             rel physics:body1 = </DR_Legs/RigidBodies/hip_servos_l_i>
@@ -1187,9 +1190,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, 0.061628416, 0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j2_l_i" (
@@ -1199,7 +1199,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_l_i>
@@ -1209,9 +1212,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.7629704, 0.068558566, -0.05752747, -0.6402082)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_l_i" (
@@ -1266,19 +1266,19 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
-            rel physics:body0 = </DR_Legs/RigidBodies/foot_l>
-            rel physics:body1 = </DR_Legs/RigidBodies/ankle_bracket_b_l_i>
-            point3f physics:localPos0 = (-0.0026218395, -0.032362416, 0.014059638)
-            point3f physics:localPos1 = (0.0010595453, -0.0060089943, -7.050231e-9)
-            quatf physics:localRot0 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
-            quatf physics:localRot1 = (0.7629104, -0.069222845, 0.058084864, -0.6401578)
+            rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_l_i>
+            rel physics:body1 = </DR_Legs/RigidBodies/foot_l>
+            point3f physics:localPos0 = (0.0010595453, -0.0060089943, -7.050231e-9)
+            point3f physics:localPos1 = (-0.0026218395, -0.032362416, 0.014059638)
+            quatf physics:localRot0 = (-0.058084864, 0.6401578, 0.7629104, -0.069222845)
+            quatf physics:localRot1 = (-0.058084864, 0.6401578, 0.7629104, -0.069222845)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j7_l_i" (
@@ -1288,7 +1288,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_l_i>
@@ -1298,9 +1301,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.6595576, -0.38962528, 0.32693443, -0.55343455)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_l_i" (
@@ -1327,6 +1327,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_l_i>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_l_i>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0032588597, -0.0004986371, -0.063249186)
             point3f physics:localPos1 = (0.04034986, -0.004129176, 0.049305025)
             quatf physics:localRot0 = (0.7657849, -0.019939138, 0.016730923, -0.64256984)
@@ -1355,7 +1356,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_l_o>
@@ -1365,9 +1369,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.056022633, 0.6403416, 0.7631294, 0.066765174)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_l_o" (
@@ -1424,6 +1425,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/foot_l>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0010595475, 0.0060089934, 5.228326e-9)
             point3f physics:localPos1 = (-0.013648499, 0.030172877, 0.014059638)
             quatf physics:localRot0 = (-0.05952467, 0.64002556, 0.7627528, -0.07093874)
@@ -1437,7 +1439,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_l_o>
@@ -1447,9 +1452,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.32886937, 0.5522869, 0.65818995, -0.39193124)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_l_o" (
@@ -1476,6 +1478,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_l_o>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_l_o>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0035088737, -0.0005427213, -0.06323544)
             point3f physics:localPos1 = (0.036696207, 0.017866438, 0.049128935)
             quatf physics:localRot0 = (0.7657433, -0.021476122, 0.018020606, -0.642535)
@@ -1489,7 +1492,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/pelvis>
             rel physics:body1 = </DR_Legs/RigidBodies/hip_servos_r_i>
@@ -1499,9 +1505,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.70441604, 0.70441604, -0.061628416, -0.061628416)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j2_r_i" (
@@ -1511,7 +1514,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_r_i>
@@ -1521,9 +1527,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (0.068558566, 0.7629704, 0.6402082, 0.05752747)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_r_i" (
@@ -1578,19 +1581,19 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
-            rel physics:body0 = </DR_Legs/RigidBodies/foot_r>
-            rel physics:body1 = </DR_Legs/RigidBodies/ankle_bracket_b_r_i>
-            point3f physics:localPos0 = (-0.0026218148, 0.03236255, 0.0140596405)
-            point3f physics:localPos1 = (0.0010595476, 0.0060089934, -5.228582e-9)
-            quatf physics:localRot0 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
-            quatf physics:localRot1 = (0.7629104, 0.069222845, 0.058084864, 0.6401578)
+            rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_r_i>
+            rel physics:body1 = </DR_Legs/RigidBodies/foot_r>
+            point3f physics:localPos0 = (0.0010595476, 0.0060089934, -5.228582e-9)
+            point3f physics:localPos1 = (-0.0026218148, 0.03236255, 0.0140596405)
+            quatf physics:localRot0 = (-0.058084864, -0.6401578, 0.7629104, 0.069222845)
+            quatf physics:localRot1 = (-0.058084864, -0.6401578, 0.7629104, 0.069222845)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j7_r_i" (
@@ -1600,7 +1603,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_r_i>
@@ -1610,9 +1616,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38962528, 0.6595576, 0.55343455, -0.32693443)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_r_i" (
@@ -1639,6 +1642,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_r_i>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_r_i>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0032328705, 0.0006460301, -0.063249186)
             point3f physics:localPos1 = (0.040375788, 0.0042765774, 0.049304985)
             quatf physics:localRot0 = (-0.64256984, 0.016730923, -0.019939138, 0.7657849)
@@ -1667,7 +1671,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/upperleg_link_r_o>
@@ -1677,9 +1684,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.6403416, -0.056022633, 0.066765174, 0.7631294)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j3_r_o" (
@@ -1736,6 +1740,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/ankle_bracket_b_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/foot_r>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0010595495, -0.0060089934, -4.9155724e-9)
             point3f physics:localPos1 = (-0.013648474, -0.030172743, 0.0140596405)
             quatf physics:localRot0 = (0.48918638, 0.5895089, 0.4946567, 0.41047612)
@@ -1749,7 +1754,10 @@ def Xform "DR_Legs"
             }
         )
         {
+            float drive:angular:physics:damping = 0.017453292
             float drive:angular:physics:maxForce = 100
+            float drive:angular:physics:stiffness = 0.87266463
+            uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/hip_servos_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/servohorn_r_o>
@@ -1759,9 +1767,6 @@ def Xform "DR_Legs"
             quatf physics:localRot1 = (-0.38575703, -0.5141667, 0.61276007, 0.45972732)
             float physics:lowerLimit = -180
             float physics:upperLimit = 180
-            float drive:angular:physics:stiffness = 0.872664626
-            float drive:angular:physics:damping = 0.017453293
-            uniform token drive:angular:physics:type = "force"  # can be in {"force", "acceleration"}
         }
 
         def PhysicsRevoluteJoint "j8_r_o" (
@@ -1788,6 +1793,7 @@ def Xform "DR_Legs"
             uniform token physics:axis = "X"
             rel physics:body0 = </DR_Legs/RigidBodies/upperleg_rod_r_o>
             rel physics:body1 = </DR_Legs/RigidBodies/lowerleg_link_r_o>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.0034828843, 0.0006901143, -0.06323544)
             point3f physics:localPos1 = (0.036722384, -0.0177191, 0.049129155)
             quatf physics:localRot0 = (-0.642535, 0.018020606, -0.021476122, 0.7657433)
@@ -1807,3 +1813,4 @@ def Xform "DR_Legs"
         }
     }
 }
+

--- a/disneyresearch/dr_testmech/README.md
+++ b/disneyresearch/dr_testmech/README.md
@@ -8,6 +8,9 @@ DR Test Mechanism (a.k.a. DR TestMech) is a teeny-tiny toy mechanism that serves
 
 ## Changelog
 
+### [06/12/2026]
+- Add articulation to model.
+
 ### [01/11/2025]
 - Initial release.
 

--- a/disneyresearch/dr_testmech/usd/dr_testmech.usda
+++ b/disneyresearch/dr_testmech/usd/dr_testmech.usda
@@ -19,7 +19,7 @@ def Xform "DR_TestMech"
     def Scope "RigidBodies"
     {
         def Xform "base" (
-            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+            prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsArticulationRootAPI"]
             customData = {
                 string uuid = "0ece88e3-361c-4282-bff0-a0b23df4369a"
             }
@@ -425,6 +425,7 @@ def Xform "DR_TestMech"
         {
             rel physics:body0 = </DR_TestMech/RigidBodies/driver>
             rel physics:body1 = </DR_TestMech/RigidBodies/link1>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (-0.000019112227, -0.005955217, 0.0042244885)
             point3f physics:localPos1 = (-0.03598901, -0.010356778, -0.001943799)
             quatf physics:localRot0 = (0.70710677, 0.5, 0.5, 0)
@@ -432,38 +433,31 @@ def Xform "DR_TestMech"
         }
 
         def PhysicsJoint "link1_2" (
-            prepend apiSchemas = [
-                "PhysicsLimitAPI:transX",
-                "PhysicsLimitAPI:transY",
-                "PhysicsLimitAPI:transZ",
-                "PhysicsLimitAPI:rotX",
-                "PhysicsLimitAPI:rotY",
-                "PhysicsLimitAPI:rotZ",
-            ]
+            prepend apiSchemas = ["PhysicsLimitAPI:transX", "PhysicsLimitAPI:transY", "PhysicsLimitAPI:transZ", "PhysicsLimitAPI:rotX", "PhysicsLimitAPI:rotY", "PhysicsLimitAPI:rotZ"]
             customData = {
                 string dofs = "universal"
                 string uuid = "8a92ec0e-cd1c-4799-8734-e23989c62f32"
             }
         )
         {
-            rel physics:body0 = </DR_TestMech/RigidBodies/link1>
-            rel physics:body1 = </DR_TestMech/RigidBodies/slider>
-            point3f physics:localPos0 = (0.03598901, 0.010356778, 0.0019437991)
-            point3f physics:localPos1 = (7.246e-9, 0.0030371458, 0.01632974)
-            quatf physics:localRot0 = (-0.66036534, 0.004958965, 0.7251846, -0.19493671)
-            quatf physics:localRot1 = (-0.66036534, 0.004958965, 0.7251846, -0.19493671)
-            float limit:transX:physics:low = 1
-            float limit:transX:physics:high = -1
-            float limit:transY:physics:low = 1
-            float limit:transY:physics:high = -1
-            float limit:transZ:physics:low = 1
-            float limit:transZ:physics:high = -1
-            float limit:rotX:physics:low = -180
             float limit:rotX:physics:high = 180
-            float limit:rotY:physics:low = -180
+            float limit:rotX:physics:low = -180
             float limit:rotY:physics:high = 180
-            float limit:rotZ:physics:low = 1
+            float limit:rotY:physics:low = -180
             float limit:rotZ:physics:high = -1
+            float limit:rotZ:physics:low = 1
+            float limit:transX:physics:high = -1
+            float limit:transX:physics:low = 1
+            float limit:transY:physics:high = -1
+            float limit:transY:physics:low = 1
+            float limit:transZ:physics:high = -1
+            float limit:transZ:physics:low = 1
+            rel physics:body0 = </DR_TestMech/RigidBodies/slider>
+            rel physics:body1 = </DR_TestMech/RigidBodies/link1>
+            point3f physics:localPos0 = (7.246e-9, 0.0030371458, 0.01632974)
+            point3f physics:localPos1 = (0.03598901, 0.010356778, 0.0019437991)
+            quatf physics:localRot0 = (0.51628947, 0.32910774, 0.60478988, 0.50927643)
+            quatf physics:localRot1 = (0.51628947, 0.32910774, 0.60478988, 0.50927643)
         }
 
         def PhysicsSphericalJoint "link2_1" (
@@ -474,6 +468,7 @@ def Xform "DR_TestMech"
         {
             rel physics:body0 = </DR_TestMech/RigidBodies/slider>
             rel physics:body1 = </DR_TestMech/RigidBodies/link2>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (7.246e-9, 0.0048656906, 0.026161138)
             point3f physics:localPos1 = (0.0061029703, -0.031342912, 0.0196628)
             quatf physics:localRot0 = (0.5552025, 0.37635413, -0.31014013, 0.6737365)
@@ -496,38 +491,31 @@ def Xform "DR_TestMech"
         }
 
         def PhysicsJoint "link3_1" (
-            prepend apiSchemas = [
-                "PhysicsLimitAPI:transX",
-                "PhysicsLimitAPI:transY",
-                "PhysicsLimitAPI:transZ",
-                "PhysicsLimitAPI:rotX",
-                "PhysicsLimitAPI:rotY",
-                "PhysicsLimitAPI:rotZ",
-            ]
+            prepend apiSchemas = ["PhysicsLimitAPI:transX", "PhysicsLimitAPI:transY", "PhysicsLimitAPI:transZ", "PhysicsLimitAPI:rotX", "PhysicsLimitAPI:rotY", "PhysicsLimitAPI:rotZ"]
             customData = {
                 string dofs = "universal"
                 string uuid = "783f3717-2c2d-46e0-9606-0588045e4d2f"
             }
         )
         {
+            float limit:rotX:physics:high = 180
+            float limit:rotX:physics:low = -180
+            float limit:rotY:physics:high = 180
+            float limit:rotY:physics:low = -180
+            float limit:rotZ:physics:high = -1
+            float limit:rotZ:physics:low = 1
+            float limit:transX:physics:high = -1
+            float limit:transX:physics:low = 1
+            float limit:transY:physics:high = -1
+            float limit:transY:physics:low = 1
+            float limit:transZ:physics:high = -1
+            float limit:transZ:physics:low = 1
             rel physics:body0 = </DR_TestMech/RigidBodies/slider>
             rel physics:body1 = </DR_TestMech/RigidBodies/link3>
             point3f physics:localPos0 = (7.246e-9, 0.0012086012, 0.0064983387)
             point3f physics:localPos1 = (-0.011397031, -0.022175519, 0.0018314008)
             quatf physics:localRot0 = (0.73026824, 0.6280843, -0.26245406, -0.05776094)
             quatf physics:localRot1 = (0.73026824, 0.6280843, -0.26245406, -0.05776094)
-            float limit:transX:physics:low = 1
-            float limit:transX:physics:high = -1
-            float limit:transY:physics:low = 1
-            float limit:transY:physics:high = -1
-            float limit:transZ:physics:low = 1
-            float limit:transZ:physics:high = -1
-            float limit:rotX:physics:low = -180
-            float limit:rotX:physics:high = 180
-            float limit:rotY:physics:low = -180
-            float limit:rotY:physics:high = 180
-            float limit:rotZ:physics:low = 1
-            float limit:rotZ:physics:high = -1
         }
 
         def PhysicsSphericalJoint "link3_2" (
@@ -538,6 +526,7 @@ def Xform "DR_TestMech"
         {
             rel physics:body0 = </DR_TestMech/RigidBodies/link3>
             rel physics:body1 = </DR_TestMech/RigidBodies/cartlink>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (0.011397028, 0.02217552, -0.0018313992)
             point3f physics:localPos1 = (0, 0, 0.002127259)
             quatf physics:localRot0 = (-0.55722076, -0.25853962, 0.6297057, -0.47553447)
@@ -545,38 +534,31 @@ def Xform "DR_TestMech"
         }
 
         def PhysicsJoint "base_slider" (
-            prepend apiSchemas = [
-                "PhysicsLimitAPI:transX",
-                "PhysicsLimitAPI:transY",
-                "PhysicsLimitAPI:transZ",
-                "PhysicsLimitAPI:rotX",
-                "PhysicsLimitAPI:rotY",
-                "PhysicsLimitAPI:rotZ",
-            ]
+            prepend apiSchemas = ["PhysicsLimitAPI:transX", "PhysicsLimitAPI:transY", "PhysicsLimitAPI:transZ", "PhysicsLimitAPI:rotX", "PhysicsLimitAPI:rotY", "PhysicsLimitAPI:rotZ"]
             customData = {
                 string dofs = "cylindrical"
                 string uuid = "9d54166d-5944-4ea1-85a0-0f25fb69e51e"
             }
         )
         {
+            float limit:rotX:physics:high = 180
+            float limit:rotX:physics:low = -180
+            float limit:rotY:physics:high = -1
+            float limit:rotY:physics:low = 1
+            float limit:rotZ:physics:high = -1
+            float limit:rotZ:physics:low = 1
+            float limit:transX:physics:high = inf
+            float limit:transX:physics:low = -inf
+            float limit:transY:physics:high = -1
+            float limit:transY:physics:low = 1
+            float limit:transZ:physics:high = -1
+            float limit:transZ:physics:low = 1
             rel physics:body0 = </DR_TestMech/RigidBodies/base>
             rel physics:body1 = </DR_TestMech/RigidBodies/slider>
             point3f physics:localPos0 = (0.013708677, -0.028778354, 0.014477081)
             point3f physics:localPos1 = (7.246e-9, -0.002448488, -0.013164462)
             quatf physics:localRot0 = (0.7690431, 0.639197, -8.5380934e-17, 7.096512e-17)
             quatf physics:localRot1 = (0.7690431, 0.639197, -8.5380934e-17, 7.096512e-17)
-            float limit:transX:physics:low = -inf
-            float limit:transX:physics:high = inf
-            float limit:transY:physics:low = 1
-            float limit:transY:physics:high = -1
-            float limit:transZ:physics:low = 1
-            float limit:transZ:physics:high = -1
-            float limit:rotX:physics:low = -180
-            float limit:rotX:physics:high = 180
-            float limit:rotY:physics:low = 1
-            float limit:rotY:physics:high = -1
-            float limit:rotZ:physics:low = 1
-            float limit:rotZ:physics:high = -1
         }
 
         def PhysicsRevoluteJoint "base_clevis" (
@@ -631,6 +613,7 @@ def Xform "DR_TestMech"
         {
             rel physics:body0 = </DR_TestMech/RigidBodies/cartlink>
             rel physics:body1 = </DR_TestMech/RigidBodies/endeffector>
+            uniform bool physics:excludeFromArticulation = 1
             point3f physics:localPos0 = (0, 0, 0.002127259)
             point3f physics:localPos1 = (0.0060903947, 0.0060903947, -0.008613119)
             quatf physics:localRot0 = (-0.55722076, -0.25853962, 0.6297057, -0.47553447)
@@ -638,38 +621,31 @@ def Xform "DR_TestMech"
         }
 
         def PhysicsJoint "driver_ee" (
-            prepend apiSchemas = [
-                "PhysicsLimitAPI:transX",
-                "PhysicsLimitAPI:transY",
-                "PhysicsLimitAPI:transZ",
-                "PhysicsLimitAPI:rotX",
-                "PhysicsLimitAPI:rotY",
-                "PhysicsLimitAPI:rotZ",
-            ]
+            prepend apiSchemas = ["PhysicsLimitAPI:transX", "PhysicsLimitAPI:transY", "PhysicsLimitAPI:transZ", "PhysicsLimitAPI:rotX", "PhysicsLimitAPI:rotY", "PhysicsLimitAPI:rotZ"]
             customData = {
                 string dofs = "cartesian"
                 string uuid = "b983b33a-2836-4e03-98fd-37f18c861b3c"
             }
         )
         {
+            float limit:rotX:physics:high = -1
+            float limit:rotX:physics:low = 1
+            float limit:rotY:physics:high = -1
+            float limit:rotY:physics:low = 1
+            float limit:rotZ:physics:high = -1
+            float limit:rotZ:physics:low = 1
+            float limit:transX:physics:high = inf
+            float limit:transX:physics:low = -inf
+            float limit:transY:physics:high = inf
+            float limit:transY:physics:low = -inf
+            float limit:transZ:physics:high = inf
+            float limit:transZ:physics:low = -inf
             rel physics:body0 = </DR_TestMech/RigidBodies/driver>
             rel physics:body1 = </DR_TestMech/RigidBodies/endeffector>
             point3f physics:localPos0 = (-0.000019112227, -0.005955217, 0.0042244885)
             point3f physics:localPos1 = (-0.08868168, -0.057145655, 0.000993483)
             quatf physics:localRot0 = (0.70710677, 0.5, 0.5, 0)
             quatf physics:localRot1 = (0.70710677, 0.5, 0.5, 0)
-            float limit:transX:physics:low = -inf
-            float limit:transX:physics:high = inf
-            float limit:transY:physics:low = -inf
-            float limit:transY:physics:high = inf
-            float limit:transZ:physics:low = -inf
-            float limit:transZ:physics:high = inf
-            float limit:rotX:physics:low = 1
-            float limit:rotX:physics:high = -1
-            float limit:rotY:physics:low = 1
-            float limit:rotY:physics:high = -1
-            float limit:rotZ:physics:low = 1
-            float limit:rotZ:physics:high = -1
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing an asset to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description

This adds articulations to all DR Legs and DR Testmech models, making sure to set the `excludeFromArticulation` on passive revolute or spherical joints.

## Before your PR is "Ready for review"

- [x] The asset folder and file structure follows the guidelines in the [README](../README.md)
- [x] The asset license allows adding to this repository, see [README](../README.md)
- [x] A LICENSE file is present
- [x] A README.md file is present that describes the asset and its origin, and provides a changelog, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced physics articulation configuration for DR_Legs and DR_TestMech models with improved joint behavior and selective articulation control.

* **Bug Fixes**
  * Refined physics constraint tolerance parameters and drive configurations for more accurate simulation performance across multiple assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->