### PR TITLE
Set Fourbar Pole crank damping

### DIFF
--- a/fourbar_pole/usd/fourbar_pole.usda
+++ b/fourbar_pole/usd/fourbar_pole.usda
@@ -147,7 +147,7 @@ def Xform "fourbar_pole" (
         prepend apiSchemas = ["PhysicsDriveAPI:angular"]
     )
     {
-        float drive:angular:physics:damping = 0
+        float drive:angular:physics:damping = 10
         float drive:angular:physics:maxForce = 1000
         float drive:angular:physics:stiffness = 0
         uniform token drive:angular:physics:type = "force"


### PR DESCRIPTION
## Description

Set the `ground_to_crank` USD drive damping to 10 N·m·s/rad, matching the Isaac Lab Fourbar Pole swing-up configuration. We have to adjust the USD because IsaacLab is not updating the `JointTargetMode` when setting the gains from the config file, which means that Kamino ignored those gains.

## Before your PR is "Ready for review"

- [x] The asset folder and file structure follows the guidelines in the [README](../README.md)
- [x] The asset license allows adding to this repository, see [README](../README.md)
- [x] A LICENSE file is present
- [x] A README.md file is present that describes the asset and its origin, and provides a changelog, if applicable

## Validation

- Ran the focused Isaac Lab Fourbar Pole USD/Kamino import regression test with the local asset checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved damping on the ground-to-crank joint for smoother, more stable rotational motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->