### PR TITLE
Set DR Legs USD drive gains

### DIFF
--- a/disneyresearch/dr_legs/usd/dr_legs.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs.usda
@@ -42,10 +42,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -73,10 +73,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -164,10 +164,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -195,10 +195,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -286,10 +286,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -397,10 +397,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -468,10 +468,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -499,10 +499,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -590,10 +590,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -621,10 +621,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -712,10 +712,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -823,10 +823,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"

--- a/disneyresearch/dr_legs/usd/dr_legs_no_meshes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_no_meshes.usda
@@ -44,10 +44,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -75,10 +75,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -166,10 +166,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -197,10 +197,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -288,10 +288,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -399,10 +399,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -470,10 +470,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -501,10 +501,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -592,10 +592,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -623,10 +623,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -714,10 +714,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -825,10 +825,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"

--- a/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_boxes.usda
@@ -44,10 +44,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -75,10 +75,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -166,10 +166,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -197,10 +197,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -288,10 +288,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -399,10 +399,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -470,10 +470,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -501,10 +501,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -592,10 +592,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -623,10 +623,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -714,10 +714,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -825,10 +825,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"

--- a/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
+++ b/disneyresearch/dr_legs/usd/dr_legs_with_meshes_and_boxes.usda
@@ -44,10 +44,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -75,10 +75,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -166,10 +166,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -197,10 +197,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -288,10 +288,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -399,10 +399,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -470,10 +470,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -501,10 +501,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -592,10 +592,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -623,10 +623,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -714,10 +714,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"
@@ -825,10 +825,10 @@ def Xform "dr_legs"
             prepend apiSchemas = ["PhysicsDriveAPI:angular"]
         )
         {
-            custom float drive:angular:physics:damping = 0
+            custom float drive:angular:physics:damping = 0.0034906585
             custom float drive:angular:physics:maxForce = 1000
             custom float drive:angular:physics:maxVelocity = 269.86313
-            custom float drive:angular:physics:stiffness = 0
+            custom float drive:angular:physics:stiffness = 0.0872664626
             custom float drive:angular:physics:targetPosition = 0
             custom float drive:angular:physics:targetVelocity = 0
             custom token drive:angular:physics:type = "force"


### PR DESCRIPTION
## Description

Embed the Isaac Lab DR Legs implicit PD gains in each USD variant's 12 driven angular joints. The authored values use USD angular-drive units: 0.0872664626 N·m/deg stiffness and 0.0034906585 N·m·s/deg damping, equivalent to the task configuration's 5.0 N·m/rad and 0.2 N·m·s/rad.

## Before your PR is "Ready for review"

- [x] The asset folder and file structure follows the guidelines in the [README](../README.md)
- [x] The asset license allows adding to this repository, see [README](../README.md)
- [x] A LICENSE file is present
- [x] A README.md file is present that describes the asset and its origin, and provides a changelog, if applicable

## Validation

- Verified all four USD variants contain the expected gains on exactly 12 driven joints, with no zero-valued authored drive gains remaining.
- Ran `uv run python -m pytest source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved angular joint control across DR Legs configurations by adding damping and stiffness to selected revolute joints.
  * Applied the adjustment consistently across left and right, inner and outer leg assemblies.
  * Preserved existing force and velocity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->